### PR TITLE
fix: role member count

### DIFF
--- a/src/libs/askbuddiebot.ts
+++ b/src/libs/askbuddiebot.ts
@@ -1,4 +1,4 @@
-import { Client, Collection } from 'discord.js';
+import { Client, Collection, Intents } from 'discord.js';
 
 import * as commands from 'src/commands';
 import config from 'src/config';
@@ -10,7 +10,7 @@ class AskBuddieBot extends Client {
     public readonly prefix: [string, string];
 
     constructor() {
-        super();
+        super({ ws: { intents: Intents.ALL } });
         this.config = config;
         this.commandList = new Collection();
         this.prefix = ['ab', 'buddie'];


### PR DESCRIPTION
The role count was working for me without this when I tested in a server with less than 100 members.
Apparently, discord js blocks 2 intents that don't load cache on startup (Maybe, this is only for the server with 100+ members). Therefore, I have enabled all the intents right now.

Also, these two options need to be enabled in discord bot settings for this to work. 
![image](https://user-images.githubusercontent.com/44132059/128727451-b516869e-0f82-4db8-b55d-cfa7e797ded7.png)
