### PR TITLE
fix(role): accept "rolename" and "[rolename]"

### DIFF
--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -78,7 +78,9 @@ class RoleCMD extends Command {
     private async listRoles(params: Params): Promise<void> {
         const { guild, message, bot } = params;
         const botMember: GuildMember = await guild.members.fetch(bot.id);
-        const roleList = Object.keys(this.getAvailableRoles(guild, botMember));
+        const roleList = Object.keys(
+            this.getAvailableRoles(guild, botMember)
+        ).sort();
 
         if (roleList.length === 0) {
             message.channel.send('**No public role available.**');

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -4,6 +4,7 @@ import {
     Guild,
     GuildMember,
     Message,
+    MessageEmbed,
     Role,
     Snowflake
 } from 'discord.js';
@@ -77,18 +78,34 @@ class RoleCMD extends Command {
     private async listRoles(params: Params): Promise<void> {
         const { guild, message, bot } = params;
         const botMember: GuildMember = await guild.members.fetch(bot.id);
-        const roleList = this.getAvailableRoles(guild, botMember);
+        const roleList = Object.keys(this.getAvailableRoles(guild, botMember));
 
-        const rolesStr = Object.keys(roleList)
-            .map((r: string) => `[ ${r.toLowerCase()} ]`)
-            .join(' ');
+        if (roleList.length === 0) {
+            message.channel.send('**No public role available.**');
+            return;
+        }
 
-        const msg =
-            rolesStr == ''
-                ? '**No public role available.**'
-                : '**Available Roles: ** ```ini\n' + rolesStr + '```';
+        const [leftColumn, rightColumn] = [
+            roleList.splice(0, roleList.length / 2),
+            roleList
+        ];
+        const invisibleSeparator = '⁣'; // it is NOT an empty string
+        const embed = new MessageEmbed({
+            color: 0x003dbe,
+            fields: [
+                {
+                    inline: true,
+                    name: invisibleSeparator,
+                    value: leftColumn.join('\n')
+                }
+            ],
+            title: 'Available Roles'
+        });
+        if (rightColumn.length > 0) {
+            embed.addField(invisibleSeparator, rightColumn.join('\n'), true);
+        }
 
-        message.channel.send(msg);
+        message.channel.send(embed);
     }
 
     // Remove role flag

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -176,15 +176,20 @@ class RoleCMD extends Command {
         const roleList: RoleList = {};
         guild?.roles.cache.forEach((role: Role) => {
             // get list a roles below the bot role, ignore the role @everyone and ignore those it can't edit, which are probably other bot's roles
-            if (
-                botHighestPosition > role.rawPosition &&
-                role.name.toLowerCase() !== '@everyone' &&
-                role.editable
-            )
+            if (this.isAssignableRole(role, botHighestPosition))
                 roleList[role.name.toLowerCase()] = role.id;
         });
 
         return roleList;
+    }
+
+    // check if role is below the bot role, ignore the role @everyone and ignore those it can't edit, which are probably other bot's roles
+    private isAssignableRole(role: Role, botHighestPosition: number): boolean {
+        return (
+            botHighestPosition > role.rawPosition &&
+            role.name.toLowerCase() !== '@everyone' &&
+            role.editable
+        );
     }
 
     // Role count command
@@ -197,11 +202,7 @@ class RoleCMD extends Command {
         // Get available roles
         const roles: Collection<string, Role> = guild?.roles.cache.filter(
             (role: Role) => {
-                if (
-                    botHighestPosition > role.rawPosition &&
-                    role.name.toLowerCase() !== '@everyone' &&
-                    role.editable
-                ) {
+                if (this.isAssignableRole(role, botHighestPosition)) {
                     return true;
                 }
                 return false;

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -80,7 +80,7 @@ class RoleCMD extends Command {
         const roleList = this.getAvailableRoles(guild, botMember);
 
         const rolesStr = Object.keys(roleList)
-            .map((r: string) => `[ ${r.toLowerCase()} ]`)
+            .map((r: string) => `[${r.toLowerCase()}]`)
             .join(' ');
 
         const msg =
@@ -108,14 +108,17 @@ class RoleCMD extends Command {
         let found = false;
 
         member.roles.cache.forEach((role: Role) => {
+            const roleName = (
+                arg.match(/^\[(.*?)\]$/)?.[1] ?? arg
+            ).toLowerCase();
             // Find the role from the argument
-            if (role.name.toLowerCase() === arg.toLowerCase()) {
+            if (role.name.toLowerCase() === roleName.toLowerCase()) {
                 // Check if bot can remove it or not
                 if (botHighestPosition > role.rawPosition) {
                     removeRoleId = role.id;
                 } else {
                     message.channel.send(
-                        `Not enough permission to remove \`${arg}\` role`
+                        `Not enough permission to remove \`${roleName}\` role`
                     );
                 }
                 found = true;
@@ -315,7 +318,7 @@ class RoleCMD extends Command {
         });
 
         reqRoles.forEach((r: string) => {
-            const roleName = r.toLowerCase();
+            const roleName = (r.match(/^\[(.*?)\]$/)?.[1] ?? r).toLowerCase();
             const role = roleList[roleName];
             if (role !== undefined) {
                 // Check for already existing role
@@ -323,10 +326,10 @@ class RoleCMD extends Command {
                     roles.push(role);
                     rolesAdded.push(roleName);
                 } else {
-                    rolesAlreadyPresent.push(r);
+                    rolesAlreadyPresent.push(roleName);
                 }
             } else {
-                invalidRoles.push(r);
+                invalidRoles.push(roleName);
             }
         });
 

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -156,10 +156,11 @@ class RoleCMD extends Command {
         // List of guild roles
         const roleList: RoleList = {};
         guild?.roles.cache.forEach((role: Role) => {
-            // get list a roles below the bot role and ignore the role @everyone
+            // get list a roles below the bot role, ignore the role @everyone and ignore those it can't edit, which are probably other bot's roles
             if (
                 botHighestPosition > role.rawPosition &&
-                role.name.toLowerCase() !== '@everyone'
+                role.name.toLowerCase() !== '@everyone' &&
+                role.editable
             )
                 roleList[role.name.toLowerCase()] = role.id;
         });
@@ -179,7 +180,8 @@ class RoleCMD extends Command {
             (role: Role) => {
                 if (
                     botHighestPosition > role.rawPosition &&
-                    role.name.toLowerCase() !== '@everyone'
+                    role.name.toLowerCase() !== '@everyone' &&
+                    role.editable
                 ) {
                     return true;
                 }

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -80,7 +80,7 @@ class RoleCMD extends Command {
         const roleList = this.getAvailableRoles(guild, botMember);
 
         const rolesStr = Object.keys(roleList)
-            .map((r: string) => `[${r.toLowerCase()}]`)
+            .map((r: string) => `[ ${r.toLowerCase()} ]`)
             .join(' ');
 
         const msg =
@@ -108,17 +108,14 @@ class RoleCMD extends Command {
         let found = false;
 
         member.roles.cache.forEach((role: Role) => {
-            const roleName = (
-                arg.match(/^\[(.*?)\]$/)?.[1] ?? arg
-            ).toLowerCase();
             // Find the role from the argument
-            if (role.name.toLowerCase() === roleName.toLowerCase()) {
+            if (role.name.toLowerCase() === arg.toLowerCase()) {
                 // Check if bot can remove it or not
                 if (botHighestPosition > role.rawPosition) {
                     removeRoleId = role.id;
                 } else {
                     message.channel.send(
-                        `Not enough permission to remove \`${roleName}\` role`
+                        `Not enough permission to remove \`${arg}\` role`
                     );
                 }
                 found = true;
@@ -318,7 +315,7 @@ class RoleCMD extends Command {
         });
 
         reqRoles.forEach((r: string) => {
-            const roleName = (r.match(/^\[(.*?)\]$/)?.[1] ?? r).toLowerCase();
+            const roleName = r.toLowerCase();
             const role = roleList[roleName];
             if (role !== undefined) {
                 // Check for already existing role
@@ -326,10 +323,10 @@ class RoleCMD extends Command {
                     roles.push(role);
                     rolesAdded.push(roleName);
                 } else {
-                    rolesAlreadyPresent.push(roleName);
+                    rolesAlreadyPresent.push(r);
                 }
             } else {
-                invalidRoles.push(roleName);
+                invalidRoles.push(r);
             }
         });
 


### PR DESCRIPTION
About #31, instead of using a (long) list to show the available roles, it could instead allow both e.g. `ab role nodejs` and `ab role [nodejs]`.

In order to avoid *some* users adding unnecessary spaces, which I see impossible to work around due to the arguments parsing of the bot, modified the way they are listed and removed the spaces inside the brackets.

https://github.com/bitomic/askbuddie-bot/blob/8edb526eeb45f44642f97fe0d5dc5eb7daaf7cb4/src/commands/role.ts#L83

Possible future errors: roles including brackets in their name. ~Why would someone use brackets in a role name anyways... right?~